### PR TITLE
Fixed Typo in demo.launch for Kinova m1n6s200

### DIFF
--- a/moveit_robot_configs/m1n6s200_moveit_config/launch/demo.launch
+++ b/moveit_robot_configs/m1n6s200_moveit_config/launch/demo.launch
@@ -9,7 +9,7 @@
   <arg name="debug" default="false" />
 
   <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
-  <include file="$(find m1n6s00_moveit_config)/launch/planning_context.launch">
+  <include file="$(find m1n6s200_moveit_config)/launch/planning_context.launch">
     <arg name="load_robot_description" value="true"/>
   </include>
 


### PR DESCRIPTION
I fixed a typo in the launch file of the `demo.launch` file for the Kinova robotic arm m1n6s200.
This typo creates a problem launching this specific file.